### PR TITLE
Add live market data fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Autonomous Crypto Trader (RL)
 
-This project is a simple autonomous crypto trading bot based on Deep Q-Learning (DQN). It fetches historical crypto price data, simulates a trading environment, and trains a DQN agent to trade profitably.
+This project is a simple autonomous crypto trading bot based on Deep Q-Learning (DQN). It fetches historical and live crypto price data, simulates a trading environment, and trains a DQN agent to trade profitably.
 
 ## Features
-- Fetches market data from Binance using ccxt
+- Fetches historical and live market data from Binance using ccxt
 - Custom OpenAI Gym environment for trading simulation
 - DQN agent implemented with PyTorch
 - Training and evaluation scripts

--- a/data/market_data.py
+++ b/data/market_data.py
@@ -12,3 +12,19 @@ class MarketDataFetcher:
         df = pd.DataFrame(ohlcv, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
         df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
         return df
+
+    def fetch_live(self):
+        ticker = self.exchange.fetch_ticker(self.symbol)
+        df = pd.DataFrame([
+            {
+                'timestamp': pd.to_datetime(
+                    ticker.get('timestamp', pd.Timestamp.utcnow().timestamp() * 1000), unit='ms'
+                ),
+                'open': ticker.get('open'),
+                'high': ticker.get('high'),
+                'low': ticker.get('low'),
+                'close': ticker.get('close') or ticker.get('last'),
+                'volume': ticker.get('baseVolume'),
+            }
+        ])
+        return df


### PR DESCRIPTION
## Summary
- extend MarketDataFetcher with a `fetch_live` method to retrieve current ticker data from Binance
- document live data support in README

## Testing
- `python -m py_compile data/market_data.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c5a3218608328be7001f58ba355a6