### PR TITLE
feat: use dueling double dqn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Autonomous Crypto Trader (RL)
 
-This project is a simple autonomous crypto trading bot based on Deep Q-Learning (DQN). It fetches historical and live crypto price data, simulates a trading environment, and trains a DQN agent to trade profitably.
+This project is a simple autonomous crypto trading bot based on an enhanced Deep Q-Learning variant (Dueling Double DQN). It fetches historical and live crypto price data, simulates a trading environment, and trains the agent to trade profitably.
 
 ## Features
 - Fetches historical and live market data from Binance using ccxt
 - Custom OpenAI Gym environment for trading simulation
-- DQN agent implemented with PyTorch
+- Dueling Double DQN agent implemented with PyTorch
 - Training and evaluation scripts
 
 ## Usage
@@ -28,7 +28,7 @@ python main.py --mode eval
 ## File Structure
 - `data/market_data.py`: Fetches crypto price data
 - `env/crypto_trading_env.py`: Trading environment
-- `agent/dqn_agent.py`: DQN agent
+- `agent/dqn_agent.py`: Dueling Double DQN agent
 - `train.py`: Training loop
 - `evaluate.py`: Evaluation/backtest
 - `main.py`: Entrypoint


### PR DESCRIPTION
## Summary
- replace vanilla DQN with dueling network architecture
- update agent training to use Double DQN target selection
- refresh README to mention the advanced agent

## Testing
- `python -m py_compile agent/dqn_agent.py train.py`
- `python -m py_compile main.py evaluate.py`


------
https://chatgpt.com/codex/tasks/task_e_688c5da6d6288328a1dc980d9f944abc